### PR TITLE
Use an actual temporary directory

### DIFF
--- a/nt-run
+++ b/nt-run
@@ -249,9 +249,12 @@ flyway_install_test_data() {
     echo
     cd ${NT_DB_TEST_DATA_PATH};
 
-    TMP_MIGRATIONS_PATH=${NT_DB_TEST_DATA_PATH}/tmp_migrations;
+    TMP_MIGRATIONS_PATH=$(tempfile -s _nt-run_migrations)
+    rm $TMP_MIGRATIONS_PATH
+    mkdir $TMP_MIGRATIONS_PATH
 
-    mkdir -p ${TMP_MIGRATIONS_PATH};
+    echo "  - Migrations are in:" $TMP_MIGRATIONS_PATH
+    echo
 
     # Add our list of schema changes
     i=1


### PR DESCRIPTION
Using WSL and Docker has some form of weirdness where if a file that's visible to both WSL and Docker is deleted, it can remain visible in directories but is completely inaccessible as it's been deleted.

The simplest workaround is to not actually delete anything from within Docker containers. (Deleting files in WSL seems to always work.)

Also, sticking temporary files in a source tree is poor form.

This updates nt-run to create the temporary migration directory for Flyway in the system temp directory instead of under the test data directory. It uses `tempfile` so it should work on any platform the script can run on.